### PR TITLE
GPUImageSolidColorGenerator: race conditions

### DIFF
--- a/framework/Source/GPUImageSolidColorGenerator.m
+++ b/framework/Source/GPUImageSolidColorGenerator.m
@@ -80,7 +80,9 @@ NSString *const kGPUSolidColorFragmentShaderString = SHADER_STRING
 
     if (!CGSizeEqualToSize(inputTextureSize, CGSizeZero))
     {
-        [self newFrameReadyAtTime:kCMTimeIndefinite atIndex:0];
+        runAsynchronouslyOnVideoProcessingQueue(^{
+            [self newFrameReadyAtTime:kCMTimeIndefinite atIndex:0];
+        });
     }
 }
 
@@ -108,9 +110,11 @@ NSString *const kGPUSolidColorFragmentShaderString = SHADER_STRING
     _color.four = (GLfloat)alphaComponent;
     
 //    [self setVec4:_color forUniform:colorUniform program:filterProgram];
-    runAsynchronouslyOnVideoProcessingQueue(^{
-        [self newFrameReadyAtTime:kCMTimeIndefinite atIndex:0];
-    });
+    if (!CGSizeEqualToSize([self sizeOfFBO], CGSizeZero)) {
+        runAsynchronouslyOnVideoProcessingQueue(^{
+            [self newFrameReadyAtTime:kCMTimeIndefinite atIndex:0];
+        });
+    }
 }
 
 - (void)setUseExistingAlpha:(BOOL)useExistingAlpha;


### PR DESCRIPTION
forceProcessingAtSize needs to call newFrameReadyAtTime on the video processing queue. setColor needs to only call newFrameReadyAtTime if there is a size for the FBO already - otherwise the FBO doesn't appear to be created correctlly (no colour is seen).
